### PR TITLE
ishgroup/onCourse-roadmap#6 Search for null joins

### DIFF
--- a/buildSrc/aql/src/main/resources/Aql.g4
+++ b/buildSrc/aql/src/main/resources/Aql.g4
@@ -177,7 +177,7 @@ SEPARATOR   : '.' ;
 BooleanLiteral: 'true' | 'false';
 
 // The Null Literal
-NullLiteral: 'null';
+NullLiteral: 'null' | 'empty';
 
 Identifier: Letter LetterOrDigit*;
 fragment Letter: [a-zA-Z_];

--- a/server/src/main/java/ish/oncourse/aql/impl/converter/LazyRelationshipComparisonNode.java
+++ b/server/src/main/java/ish/oncourse/aql/impl/converter/LazyRelationshipComparisonNode.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright ish group pty ltd. All rights reserved. https://www.ish.com.au
+ * No copying or use of this code is allowed without permission in writing from ish.
+ */
+
+package ish.oncourse.aql.impl.converter;
+
+import java.util.List;
+
+import ish.oncourse.aql.impl.CompilationContext;
+import ish.oncourse.aql.impl.ExpressionUtil;
+import ish.oncourse.aql.impl.LazyExpressionNode;
+import ish.oncourse.aql.impl.Op;
+import org.apache.cayenne.exp.parser.ASTEqual;
+import org.apache.cayenne.exp.parser.ASTNotEqual;
+import org.apache.cayenne.exp.parser.ASTObjPath;
+import org.apache.cayenne.exp.parser.ASTScalar;
+import org.apache.cayenne.exp.parser.SimpleNode;
+
+public class LazyRelationshipComparisonNode extends LazyExpressionNode {
+
+    private final Op op;
+
+    public LazyRelationshipComparisonNode(Op op) {
+        this.op = op;
+    }
+
+    @Override
+    public SimpleNode resolveParent(SimpleNode parent, List<SimpleNode> args, CompilationContext ctx) {
+        return this;
+    }
+
+    @Override
+    public SimpleNode resolveSelf(CompilationContext ctx) {
+        SimpleNode node;
+        switch (op) {
+            case EQ:
+                node = new ASTEqual();
+                break;
+            case NE:
+                node = new ASTNotEqual();
+                break;
+            default:
+                ctx.reportError(-1, -1, "Unexpected operator for the relationship: " + op);
+                return this;
+        }
+
+        ASTObjPath path = (ASTObjPath)jjtGetChild(0);
+        String outerPath = path.getPath() + "+";
+
+        ExpressionUtil.addChild(node, new ASTObjPath(outerPath), 0);
+        ExpressionUtil.addChild(node, new ASTScalar(null), 1);
+
+        return node;
+    }
+}

--- a/server/src/test/groovy/ish/oncourse/aql/impl/AntlrAqlServiceTest.groovy
+++ b/server/src/test/groovy/ish/oncourse/aql/impl/AntlrAqlServiceTest.groovy
@@ -644,6 +644,13 @@ class AntlrAqlServiceTest {
     }
 
     @Test
+    void testEmptyToMany() {
+        CompilationResult result = service
+                .compile("contact.address is empty", null, getMockContext())
+        assertValid("contact.address = null", result)
+    }
+
+    @Test
     void testNegativeInt() {
         CompilationResult result = service
                 .compile("contact.path = -1"

--- a/server/src/test/groovy/ish/oncourse/aql/impl/AqlTestIT.groovy
+++ b/server/src/test/groovy/ish/oncourse/aql/impl/AqlTestIT.groovy
@@ -79,4 +79,21 @@ class AqlTestIT extends CayenneIshTestCase {
         assertEquals(1, contacts.size())
         assertEquals("1abc", contacts.get(0).uniqueCode)
     }
+
+    @Test
+    void testMessagesIsEmpty() {
+        CompilationResult result = aqlService
+                .compile("messages is empty",
+                        Contact.class, cayenneContext)
+        assertTrue(result.getCayenneExpression().isPresent())
+        assertTrue(result.getErrors().isEmpty())
+
+        List<Contact> contacts = ObjectSelect.query(Contact)
+                .where(result.getCayenneExpression().get())
+                .orderBy(Contact.UNIQUE_CODE.asc())
+                .select(cayenneContext)
+        assertEquals(2, contacts.size())
+        assertEquals("2abc", contacts.get(0).uniqueCode)
+        assertEquals("2abcd", contacts.get(1).uniqueCode)
+    }
 }


### PR DESCRIPTION
This PR enables the following syntax in AQL: `course.classes is EMPTY`