### PR TITLE
ishgroup/onCourse-roadmap#12 Clustered onCourse servers

### DIFF
--- a/server/src/main/java/ish/oncourse/server/services/SchedulerService.java
+++ b/server/src/main/java/ish/oncourse/server/services/SchedulerService.java
@@ -55,12 +55,13 @@ public class SchedulerService implements ISchedulerService {
 
 		var aJob = JobBuilder.newJob(provider).withIdentity(id, groupId).build();
 
-		var aTrigger = TriggerBuilder.newTrigger().withIdentity(id + TRIGGER_POSTFIX, groupId)
-			.withSchedule(simpleSchedule().withIntervalInSeconds(intervalInSeconds).repeatForever()).build();
-
-		scheduler.scheduleJob(aJob, aTrigger);
-		if (startNow) {
-			scheduler.triggerJob(aTrigger.getJobKey());
+		if(!scheduler.checkExists(aJob.getKey())) {
+			var aTrigger = TriggerBuilder.newTrigger().withIdentity(id + TRIGGER_POSTFIX, groupId)
+					.withSchedule(simpleSchedule().withIntervalInSeconds(intervalInSeconds).repeatForever()).build();
+			scheduler.scheduleJob(aJob, aTrigger);
+			if (startNow) {
+				scheduler.triggerJob(aTrigger.getJobKey());
+			}
 		}
 	}
 
@@ -77,12 +78,14 @@ public class SchedulerService implements ISchedulerService {
 
 		var aJob = JobBuilder.newJob(provider).withIdentity(id, groupId).build();
 
-		var aTrigger = TriggerBuilder.newTrigger().withIdentity(id + TRIGGER_POSTFIX, groupId)
-			.withSchedule(CronScheduleBuilder.cronSchedule(cron).inTimeZone(TimeZoneUtil.getTimeZone(timeZoneId))).build();
+		if(!scheduler.checkExists(aJob.getKey())) {
+			var aTrigger = TriggerBuilder.newTrigger().withIdentity(id + TRIGGER_POSTFIX, groupId)
+					.withSchedule(CronScheduleBuilder.cronSchedule(cron).inTimeZone(TimeZoneUtil.getTimeZone(timeZoneId))).build();
 
-		scheduler.scheduleJob(aJob, aTrigger);
-		if (startNow) {
-			scheduler.triggerJob(aTrigger.getJobKey());
+			scheduler.scheduleJob(aJob, aTrigger);
+			if (startNow) {
+				scheduler.triggerJob(aTrigger.getJobKey());
+			}
 		}
 	}
 

--- a/server/src/main/resources/database/quartz.yml
+++ b/server/src/main/resources/database/quartz.yml
@@ -1,0 +1,623 @@
+# see original migration:
+#  https://raw.githubusercontent.com/quartz-scheduler/quartz/master/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/liquibase.quartz.init.xml
+databaseChangeLog:
+  - changeSet:
+      id: quartz-init
+      author: ntimofeev
+      objectQuotingStrategy: LEGACY
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: LOCK_NAME
+                  type: VARCHAR(40)
+            tableName: QRTZ_LOCKS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, LOCK_NAME
+            tableName: QRTZ_LOCKS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: ENTRY_ID
+                  type: VARCHAR(95)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: INSTANCE_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: FIRED_TIME
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_TIME
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: PRIORITY
+                  type: INTEGER
+              - column:
+                  constraints:
+                    nullable: false
+                  name: STATE
+                  type: VARCHAR(16)
+              - column:
+                  name: JOB_NAME
+                  type: VARCHAR(200)
+              - column:
+                  name: JOB_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  name: IS_NONCONCURRENT
+                  type: BOOLEAN
+              - column:
+                  name: REQUESTS_RECOVERY
+                  type: BOOLEAN
+            tableName: QRTZ_FIRED_TRIGGERS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, ENTRY_ID
+            tableName: QRTZ_FIRED_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: INSTANCE_NAME
+              - column:
+                  name: REQUESTS_RECOVERY
+            indexName: IDX_QRTZ_FT_INST_JOB_REQ_RCVRY
+            tableName: QRTZ_FIRED_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: JOB_NAME
+              - column:
+                  name: JOB_GROUP
+            indexName: IDX_QRTZ_FT_J_G
+            tableName: QRTZ_FIRED_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: JOB_GROUP
+            indexName: IDX_QRTZ_FT_JG
+            tableName: QRTZ_FIRED_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: TRIGGER_NAME
+              - column:
+                  name: TRIGGER_GROUP
+            indexName: IDX_QRTZ_FT_T_G
+            tableName: QRTZ_FIRED_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: TRIGGER_GROUP
+            indexName: IDX_QRTZ_FT_TG
+            tableName: QRTZ_FIRED_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: INSTANCE_NAME
+            indexName: IDX_QRTZ_FT_TRIG_INST_NAME
+            tableName: QRTZ_FIRED_TRIGGERS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: CALENDAR_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: CALENDAR
+                  type: BLOB
+            tableName: QRTZ_CALENDARS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, CALENDAR_NAME
+            tableName: QRTZ_CALENDARS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_GROUP
+                  type: VARCHAR(200)
+            tableName: QRTZ_PAUSED_TRIGGER_GRPS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, TRIGGER_GROUP
+            tableName: QRTZ_PAUSED_TRIGGER_GRPS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: INSTANCE_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: LAST_CHECKIN_TIME
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: CHECKIN_INTERVAL
+                  type: BIGINT
+            tableName: QRTZ_SCHEDULER_STATE
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, INSTANCE_NAME
+            tableName: QRTZ_SCHEDULER_STATE
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: JOB_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: JOB_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  name: DESCRIPTION
+                  type: VARCHAR(250)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: JOB_CLASS_NAME
+                  type: VARCHAR(250)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: IS_DURABLE
+                  type: BOOLEAN
+              - column:
+                  constraints:
+                    nullable: false
+                  name: IS_NONCONCURRENT
+                  type: BOOLEAN
+              - column:
+                  constraints:
+                    nullable: false
+                  name: IS_UPDATE_DATA
+                  type: BOOLEAN
+              - column:
+                  constraints:
+                    nullable: false
+                  name: REQUESTS_RECOVERY
+                  type: BOOLEAN
+              - column:
+                  name: JOB_DATA
+                  type: BLOB
+            tableName: QRTZ_JOB_DETAILS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, JOB_NAME, JOB_GROUP
+            tableName: QRTZ_JOB_DETAILS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: JOB_GROUP
+            indexName: IDX_QRTZ_J_GRP
+            tableName: QRTZ_JOB_DETAILS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: REQUESTS_RECOVERY
+            indexName: IDX_QRTZ_J_REQ_RECOVERY
+            tableName: QRTZ_JOB_DETAILS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: JOB_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: JOB_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  name: DESCRIPTION
+                  type: VARCHAR(250)
+              - column:
+                  name: NEXT_FIRE_TIME
+                  type: BIGINT
+              - column:
+                  name: PREV_FIRE_TIME
+                  type: BIGINT
+              - column:
+                  name: PRIORITY
+                  type: INTEGER
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_STATE
+                  type: VARCHAR(16)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_TYPE
+                  type: VARCHAR(8)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: START_TIME
+                  type: BIGINT
+              - column:
+                  name: END_TIME
+                  type: BIGINT
+              - column:
+                  name: CALENDAR_NAME
+                  type: VARCHAR(200)
+              - column:
+                  name: MISFIRE_INSTR
+                  type: smallint
+              - column:
+                  name: JOB_DATA
+                  type: BLOB
+            tableName: QRTZ_TRIGGERS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: CALENDAR_NAME
+            indexName: IDX_QRTZ_T_C
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: TRIGGER_GROUP
+            indexName: IDX_QRTZ_T_G
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: JOB_GROUP
+            indexName: IDX_QRTZ_T_JG
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: TRIGGER_GROUP
+              - column:
+                  name: TRIGGER_STATE
+            indexName: IDX_QRTZ_T_N_G_STATE
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: TRIGGER_NAME
+              - column:
+                  name: TRIGGER_GROUP
+              - column:
+                  name: TRIGGER_STATE
+            indexName: IDX_QRTZ_T_N_STATE
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: NEXT_FIRE_TIME
+            indexName: IDX_QRTZ_T_NEXT_FIRE_TIME
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: MISFIRE_INSTR
+              - column:
+                  name: NEXT_FIRE_TIME
+            indexName: IDX_QRTZ_T_NFT_MISFIRE
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: TRIGGER_STATE
+              - column:
+                  name: NEXT_FIRE_TIME
+            indexName: IDX_QRTZ_T_NFT_ST
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: MISFIRE_INSTR
+              - column:
+                  name: NEXT_FIRE_TIME
+              - column:
+                  name: TRIGGER_STATE
+            indexName: IDX_QRTZ_T_NFT_ST_MISFIRE
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: MISFIRE_INSTR
+              - column:
+                  name: NEXT_FIRE_TIME
+              - column:
+                  name: TRIGGER_GROUP
+              - column:
+                  name: TRIGGER_STATE
+            indexName: IDX_QRTZ_T_NFT_ST_MISFIRE_GRP
+            tableName: QRTZ_TRIGGERS
+        - createIndex:
+            columns:
+              - column:
+                  name: SCHED_NAME
+              - column:
+                  name: TRIGGER_STATE
+            indexName: IDX_QRTZ_T_STATE
+            tableName: QRTZ_TRIGGERS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  name: BLOB_DATA
+                  type: BLOB
+            tableName: QRTZ_BLOB_TRIGGERS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            tableName: QRTZ_BLOB_TRIGGERS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  name: STR_PROP_1
+                  type: VARCHAR(512)
+              - column:
+                  name: STR_PROP_2
+                  type: VARCHAR(512)
+              - column:
+                  name: STR_PROP_3
+                  type: VARCHAR(512)
+              - column:
+                  name: INT_PROP_1
+                  type: INTEGER
+              - column:
+                  name: INT_PROP_2
+                  type: INTEGER
+              - column:
+                  name: LONG_PROP_1
+                  type: BIGINT
+              - column:
+                  name: LONG_PROP_2
+                  type: BIGINT
+              - column:
+                  name: DEC_PROP_1
+                  type: NUMERIC(13,4)
+              - column:
+                  name: DEC_PROP_2
+                  type: NUMERIC(13,4)
+              - column:
+                  name: BOOL_PROP_1
+                  type: BOOLEAN
+              - column:
+                  name: BOOL_PROP_2
+                  type: BOOLEAN
+            tableName: QRTZ_SIMPROP_TRIGGERS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            tableName: QRTZ_SIMPROP_TRIGGERS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: CRON_EXPRESSION
+                  type: VARCHAR(120)
+              - column:
+                  name: TIME_ZONE_ID
+                  type: VARCHAR(80)
+            tableName: QRTZ_CRON_TRIGGERS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            tableName: QRTZ_CRON_TRIGGERS
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                  name: SCHED_NAME
+                  type: VARCHAR(120)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_NAME
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TRIGGER_GROUP
+                  type: VARCHAR(200)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: REPEAT_COUNT
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: REPEAT_INTERVAL
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: TIMES_TRIGGERED
+                  type: BIGINT
+            tableName: QRTZ_SIMPLE_TRIGGERS
+        - addPrimaryKey:
+            columnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            tableName: QRTZ_SIMPLE_TRIGGERS
+        - addForeignKeyConstraint:
+            baseColumnNames: SCHED_NAME, JOB_NAME, JOB_GROUP
+            baseTableName: QRTZ_TRIGGERS
+            constraintName: QRTZ_TRIGGERS_SCHED_NAME_FKEY
+            referencedColumnNames: SCHED_NAME, JOB_NAME, JOB_GROUP
+            referencedTableName: QRTZ_JOB_DETAILS
+        - addForeignKeyConstraint:
+            baseColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            baseTableName: QRTZ_SIMPLE_TRIGGERS
+            constraintName: QRTZ_SIMPLE_TRIGGERS_SCHED_NAME_FKEY
+            referencedColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            referencedTableName: QRTZ_TRIGGERS
+        - addForeignKeyConstraint:
+            baseColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            baseTableName: QRTZ_CRON_TRIGGERS
+            constraintName: QRTZ_CRON_TRIGGERS_SCHED_NAME_FKEY
+            referencedColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            referencedTableName: QRTZ_TRIGGERS
+        - addForeignKeyConstraint:
+            baseColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            baseTableName: QRTZ_SIMPROP_TRIGGERS
+            constraintName: QRTZ_SIMPROP_TRIGGERS_SCHED_NAME_FKEY
+            referencedColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            referencedTableName: QRTZ_TRIGGERS
+        - addForeignKeyConstraint:
+            baseColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            baseTableName: QRTZ_BLOB_TRIGGERS
+            constraintName: QRTZ_BLOB_TRIGGERS_SCHED_NAME_FKEY
+            referencedColumnNames: SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP
+            referencedTableName: QRTZ_TRIGGERS


### PR DESCRIPTION
This PR enables Quartz jobs persistence in the DB. This allows to use it in a clustered environment.
Minor note: jobs also persisted across server restarts and should be additionally shutdown if needed.