### PR TITLE
Update Google Fonts import URLs

### DIFF
--- a/buildSrc/swagger/src/main/resources/swaggerTemplates/html/assets/css/style.css
+++ b/buildSrc/swagger/src/main/resources/swaggerTemplates/html/assets/css/style.css
@@ -9,7 +9,7 @@
  * See the GNU Affero General Public License for more details.
  */
 
-@import url('https://fonts.googleapis.com/css?family=Merriweather:300,400,700|Port+Lligat+Slab');
+@import url('https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Port+Lligat+Slab&display=swap');
 
 /* Reset - Blank canvas, go. */
 html, body, div, span, applet, object, iframe,

--- a/client-html/src/dev/mock/data/entities/messages.ts
+++ b/client-html/src/dev/mock/data/entities/messages.ts
@@ -222,7 +222,7 @@ export function mockMessage() {
       + '    </style>\n'
       + '\n'
       + '    <style type="text/css" media="screen">\n'
-      + '        @import url(http://fonts.googleapis.com/css?family=Oxygen:400,700);\n'
+      + '        @import url("https://fonts.googleapis.com/css2?family=Oxygen:wght@400;700&display=swap");\n'
       + '    </style>\n'
       + '\n'
       + '    <style type="text/css" media="screen">\n'

--- a/server/src/main/resources/messages/ish.email.header.html
+++ b/server/src/main/resources/messages/ish.email.header.html
@@ -164,7 +164,7 @@
     </style>
 
     <style type="text/css" media="screen">
-        @import url(http://fonts.googleapis.com/css?family=Oxygen:400,700);
+        @import url("https://fonts.googleapis.com/css2?family=Oxygen:wght@400;700&display=swap");
     </style>
 
     <style type="text/css" media="screen">


### PR DESCRIPTION
The import URLs for Google Fonts in this repo refer to the old CSS API, and 2 of them do not use HTTPS. This pull request updates the Google Fonts import URLs to use HTTPS and [CSS API v2](https://developers.google.com/fonts/docs/css2) for [font-display](https://developers.google.com/web/updates/2016/02/font-display) support.