### PR TITLE
feat: notSupportsTls13 property for smtp servers, that don't… OD-17636 

### DIFF
--- a/server/src/main/groovy/ish/oncourse/server/messaging/MailSession.groovy
+++ b/server/src/main/groovy/ish/oncourse/server/messaging/MailSession.groovy
@@ -54,7 +54,7 @@ class MailSession {
         properties.put(SMTP_IO_TIMEOUT, SMTP_IO_TIMEOUT_VALUE)
         properties.put(SMTP_HOST, smtpService.host)
         properties.put(SMTP_PORT, smtpService.port)
-        
+
         switch (smtpService.mode) {
             case SMTPService.Mode.ssl:
                 properties.put("mail.smtp.ssl.enable", "true")
@@ -63,7 +63,9 @@ class MailSession {
             case SMTPService.Mode.starttls:
                 properties.put("mail.smtp.ssl.enable", "false")
                 properties.put("mail.smtp.starttls.enable", "true")
-                properties.put("mail.smtp.ssl.protocols","TLSv1.3")
+
+                def tlsProtocol = smtpService.supportsTls13() ? "TLSv1.3" : "TLSv1.2"
+                properties.put("mail.smtp.ssl.protocols", tlsProtocol)
                 break
             case SMTPService.Mode.unsafe:
                 properties.put("mail.smtp.ssl.enable", "false")

--- a/server/src/main/groovy/ish/oncourse/server/messaging/SMTPService.groovy
+++ b/server/src/main/groovy/ish/oncourse/server/messaging/SMTPService.groovy
@@ -20,6 +20,7 @@ class SMTPService {
     private String username
     private String password
     private Mode mode = Mode.ssl
+    private Boolean notSupportsTls13 = false
 
     private static final Logger logger = LogManager.logger
 
@@ -53,7 +54,12 @@ class SMTPService {
     void setMode(String mode) {
         this.mode = Mode.byName(mode)
     }
-    
+
+    @BQConfigProperty
+    void setNotSupportsTls13(Boolean notSupportsTls13) {
+        this.notSupportsTls13 = notSupportsTls13
+    }
+
     Integer getEmail_batch() {
         return email_batch
     }
@@ -77,7 +83,11 @@ class SMTPService {
     Mode getMode() {
         return mode
     }
-    
+
+    Boolean supportsTls13() {
+        return !notSupportsTls13
+    }
+
     static enum Mode {
         ssl,
         starttls,


### PR DESCRIPTION
… support TLS v1.3, false by default. If it is set to true, then smtp session will have mail.smtp.ssl.protocols=TLSv1.2 instead of TLSv1.3