### PR TITLE
fix: remove check for freeBSD os from node plugins configura… OD-18433 

### DIFF
--- a/nodeSetup.gradle
+++ b/nodeSetup.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.github.node-gradle.node'
 
 node {
     version = '16.14.2'
-    download = System.properties['os.name'] != "FreeBSD" // FreeBSD has no binaries this plugin can install
+    download = true
     workDir = file("${project.buildDir}/nodejs")
     npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'
 }


### PR DESCRIPTION
…tion (download = false sets version of node to global instead of configured in gradle. Release and github actions don't use freeBSD, only buildbot)