### PR TITLE
fix: correct isValidEmailAddress semantics and update all callers

### DIFF
--- a/server/src/main/groovy/ish/oncourse/server/api/service/ContactApiService.groovy
+++ b/server/src/main/groovy/ish/oncourse/server/api/service/ContactApiService.groovy
@@ -489,7 +489,7 @@ class ContactApiService extends TaggableApiService<ContactDTO, Contact, ContactD
     }
 
     private void checkEmail(String email) {
-        if (isValidEmailAddress(email)) {
+        if (!StringUtils.isBlank(email) && !isValidEmailAddress(email)) {
             validator.throwClientErrorException(Contact.EMAIL.name, 'Please enter an email address in the correct format.')
         }
     }

--- a/server/src/main/groovy/ish/oncourse/server/api/v1/function/ContactFunctions.groovy
+++ b/server/src/main/groovy/ish/oncourse/server/api/v1/function/ContactFunctions.groovy
@@ -131,7 +131,7 @@ class ContactFunctions {
     }
 
     static boolean isValidEmailAddress(String email) {
-        !StringUtils.isBlank(email) && !ValidationUtil.isValidEmailAddress(email)
+        !StringUtils.isBlank(email) && ValidationUtil.isValidEmailAddress(email)
     }
 
     static void updateProfilePicture(Contact contact, DocumentDTO pictureDocument) {

--- a/server/src/main/resources/imports/avetmissStudentImport.groovy
+++ b/server/src/main/resources/imports/avetmissStudentImport.groovy
@@ -336,7 +336,7 @@ def import85(String data, Map<String, Student> importedStudents, ObjectContext c
 		aStudent.contact.workPhone = line.readString(20)
 		aStudent.contact.mobilePhone = line.readString(20)
 		String email = line.readString(80)
-		aStudent.contact.email = !isValidEmailAddress(email) ? email : null
+		aStudent.contact.email = isValidEmailAddress(email) ? email : null
 
 		// ------------------
 		// end of line

--- a/server/src/test/groovy/ish/oncourse/server/api/v1/function/ContactFunctionsTest.groovy
+++ b/server/src/test/groovy/ish/oncourse/server/api/v1/function/ContactFunctionsTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright ish group pty ltd 2024.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License version 3 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ */
+
+package ish.oncourse.server.api.v1.function
+
+import groovy.transform.CompileStatic
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.*
+
+@CompileStatic
+class ContactFunctionsTest {
+
+    @Test
+    void testIsValidEmailAddress_validEmail() {
+        assertTrue(ContactFunctions.isValidEmailAddress("test@example.com"))
+    }
+
+    @Test
+    void testIsValidEmailAddress_anotherValidEmail() {
+        assertTrue(ContactFunctions.isValidEmailAddress("user.name+tag@sub.domain.org"))
+    }
+
+    @Test
+    void testIsValidEmailAddress_invalidEmail() {
+        assertFalse(ContactFunctions.isValidEmailAddress("not-an-email"))
+    }
+
+    @Test
+    void testIsValidEmailAddress_invalidEmailMissingDomain() {
+        assertFalse(ContactFunctions.isValidEmailAddress("user@"))
+    }
+
+    @Test
+    void testIsValidEmailAddress_blankString() {
+        assertFalse(ContactFunctions.isValidEmailAddress(""))
+    }
+
+    @Test
+    void testIsValidEmailAddress_whitespaceOnly() {
+        assertFalse(ContactFunctions.isValidEmailAddress("   "))
+    }
+
+    @Test
+    void testIsValidEmailAddress_null() {
+        assertFalse(ContactFunctions.isValidEmailAddress(null))
+    }
+}

--- a/server/src/test/groovy/ish/oncourse/server/imports/avetmiss/AvetmissStudentImportTest.groovy
+++ b/server/src/test/groovy/ish/oncourse/server/imports/avetmiss/AvetmissStudentImportTest.groovy
@@ -79,6 +79,6 @@ class AvetmissStudentImportTest extends TestWithDatabase {
 
         List<Contact> withEmptyEmail = ObjectSelect.query(Contact.class)
                 .where(Contact.EMAIL.isNull()).select(cayenneContext)
-        Assertions.assertEquals(3, withEmptyEmail.size())
+        Assertions.assertEquals(4, withEmptyEmail.size())
     }
 }


### PR DESCRIPTION
- Remove spurious '!' in ContactFunctions.isValidEmailAddress so it correctly returns true for VALID emails (was true for INVALID)
- Update ContactApiService.checkEmail: add isBlank guard so null email is accepted; invert isValidEmailAddress call for new semantics
- Update avetmissStudentImport: assign email when valid, null otherwise (blank field now also maps to null instead of empty string)
- Update AvetmissStudentImportTest: expect 4 null-email contacts (blank email field now correctly maps to null, not empty string)
- Add ContactFunctionsTest covering valid/invalid/blank/null cases