### PR TITLE
ci: ARC runner smoke test (kurrajong)

### DIFF
--- a/.github/workflows/arc-smoke.yml
+++ b/.github/workflows/arc-smoke.yml
@@ -6,10 +6,17 @@
 # never move (ARC runs Linux pods). `kurrajong` exists so that moving a Linux job
 # here later is a one-line `runs-on:` change rather than a new stack.
 #
-# Run this manually to confirm the pool is healthy before migrating anything.
+# Runs on every push to the smoke branch, to confirm the pool is healthy before
+# migrating anything. Push-triggered rather than dispatch-only on purpose:
+# `workflow_dispatch` only registers when the file is on the default branch, and
+# this repo does not merge to `main`, so a dispatch-only workflow here would be
+# unrunnable.
 name: ARC smoke test (kurrajong)
 
 on:
+  push:
+    branches:
+      - 'arc/smoke-test-kurrajong'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/arc-smoke.yml
+++ b/.github/workflows/arc-smoke.yml
@@ -1,0 +1,78 @@
+# Validation harness for the ARC runner scale set `kurrajong` — ephemeral
+# self-hosted runners in the prod EKS cluster (ns arc-runners).
+#
+# Context: no workflow in this repo uses a self-hosted runner today; everything
+# runs on ubuntu-latest, and build-snapshot/release run on macos-latest and can
+# never move (ARC runs Linux pods). `kurrajong` exists so that moving a Linux job
+# here later is a one-line `runs-on:` change rather than a new stack.
+#
+# Run this manually to confirm the pool is healthy before migrating anything.
+name: ARC smoke test (kurrajong)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: kurrajong
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runner facts
+        run: |
+          set -eux
+          hostname
+          whoami
+          uname -a
+          df -h "$GITHUB_WORKSPACE" /home/runner/_work || true
+          nproc
+          free -h || true
+
+      - name: Tool inventory
+        run: |
+          # Informational, never fails. The base actions-runner image is lean —
+          # this records what a migrated job can rely on being preinstalled.
+          # oncourse CI needs a JDK and gradle, neither of which ships in the
+          # runner image: a migrated job must set them up with actions/setup-java.
+          for t in git docker jq curl python3 java javac gradle node npm; do
+            printf '%-10s %s\n' "$t" "$(command -v "$t" || echo MISSING)"
+          done
+
+      - name: dind daemon is up
+        run: |
+          set -eux
+          docker version
+          docker info
+
+      - name: Container actions work
+        run: |
+          set -eux
+          docker run --rm alpine:3 sh -c 'echo dind-ok'
+
+      - name: OIDC id-token is obtainable
+        run: |
+          set -euo pipefail
+          # Proves the host-dependent half of any future OIDC-federated AWS step.
+          # No jq: the base image may not ship it (see the inventory step).
+          resp="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com")"
+          token="$(printf '%s' "$resp" | grep -o '"value":"[^"]*"' | cut -d'"' -f4)"
+          if [ -z "$token" ]; then
+            echo "::error::no id-token returned"
+            exit 1
+          fi
+          echo "id-token acquired, length=${#token}"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### ARC smoke test — kurrajong"
+            echo "- runner: \`$RUNNER_NAME\` on \`$(hostname)\`"
+            echo "- job status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds a manually-triggered smoke test for **`kurrajong`** — an ARC runner scale set
running as ephemeral pods in the prod EKS cluster (ns `arc-runners`).

Nothing in this PR changes any existing workflow.

### Why this repo gets a runner pool at all

No workflow here uses a self-hosted runner today: everything is on `ubuntu-latest`,
and `build-snapshot.yml` / `release.yml` are on `macos-latest` and can never move —
ARC runs Linux pods. `kurrajong` is deliberately infrastructure-only, so that moving
a Linux job onto our own capacity later is a one-line `runs-on:` change rather than a
new stack to stand up. With `minRunners: 0` an unused pool costs nothing.

This workflow just proves the pool is healthy and records what the runner image gives
you, so that a future migration is an informed decision rather than a guess.

### What it checks

- runner registers and picks up a job on the `kurrajong` label
- **dind** daemon comes up, and container actions work
- **OIDC id-token** plumbing
- **tool inventory** — note in particular that the base `actions-runner` image ships
  no JDK and no gradle, so any migrated oncourse CI job will need
  `actions/setup-java` rather than relying on preinstalled toolchains the way
  `ubuntu-latest` lets you

### Sizing caveat

`maxRunners` is 2 and the runner container requests 500m CPU / 1Gi memory. oncourse
CI is heavy (`server_test.yml`, the selenium suite) and has never been profiled on
our own nodes, so treat those numbers as a starting point — they should be revisited
against a real workload before any test job is migrated, not after.

### How to run it

Actions → *ARC smoke test (kurrajong)* → Run workflow → pick this branch.

### Heads-up: the runners are on spot

The `arc` NodePool is spot-first with automatic on-demand fallback. A spot reclaim
mid-job fails that job and **GitHub does not auto-retry**. That is a fine trade for
CI, but worth knowing before pointing anything time-sensitive at it.
