### PR TITLE
ci: build the angel image on the ARC self-hosted pool, without cache export

### DIFF
--- a/.github/workflows/build-docker-and-push-ecr.yml
+++ b/.github/workflows/build-docker-and-push-ecr.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   build-and-push:
     name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code
@@ -177,8 +177,12 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ inputs.app_version != '' && inputs.app_version || '99-SNAPSHOT' }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+          # cache-to dropped: measured on ARC, exporting the gha cache took 111s of
+          # a 3m3s job and the same build without it ran in 1m31s with a
+          # byte-identical image. With an artifact that changes every build the
+          # export buys almost nothing. cache-from stays so an existing cache is
+          # still read.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Image digest
         run: |


### PR DESCRIPTION
Moves `build-docker-and-push-ecr.yml` off `ubuntu-latest` onto the ARC runner pool in EKS, and drops the gha cache export.

## Two changes

**`runs-on: ubuntu-latest` -> `self-hosted`.** The pool is repo-scoped and named `self-hosted`, so this text can only reach oncourse runners. The name is generic on purpose: the two repo-level pools are meant to become one **org-level** pool once the GitHub App is granted `Organization -> Self-hosted runners: Read and write`, and a generic label means that collapse needs no workflow edit.

Note ARC scale-set runners get **no** implicit `self-hosted` label ([issue #3330](https://github.com/actions/actions-runner-controller/issues/3330)) — the match is on the scale set *name*, verified working with a throwaway probe before this PR.

**`cache-to: type=gha,mode=max` removed.** Measured on ARC:

| | with `cache-to` | without |
|---|---|---|
| job duration | 3m3s | **1m31s** |
| `sending cache export` | 110.9s | 0 |
| image size | 360 815 908 B | identical |

With an artifact that changes every build the export earns nothing — it was over half the job. `cache-from` stays so an existing cache is still read. willow’s equivalent workflow already runs with both cache settings blanked out.

## Rehearsed beforehand
The whole path was run on ARC with `push: false` — 99-SNAPSHOT artifact (181 MiB, unpacks to 199 MiB), all six plugin jars from `oncourse-secret`, buildx, and a full `./Dockerfile` build. The image ran: Temurin 11.0.31, `onCourseServer.jar` and all six plugins present. ECR was untouched, verified via `describe-images`.

## Worth knowing
- Pool: 8 vCPU / 30 GiB spot nodes, requests 3500m/8Gi, 120Gi ephemeral disk, dind, scale-to-zero when idle.
- The runner image is lean — no `aws`, `kubectl`, `java`, `node`. This workflow is fine (`configure-aws-credentials` and `amazon-ecr-login` are bundled Node actions), but check any other workflow before moving it here.
- Spot reclaim fails a job and GitHub does not auto-retry. Karpenter will not disrupt a running job, but AWS reclaiming capacity still can.
- `build-snapshot.yml` and `release.yml` stay on `macos-latest` — ARC is Linux pods, they can never move.